### PR TITLE
Improve sorter to stream file and output dir option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# cnc-firmware
+# CNC Firmware Utilities
+
+This repository now includes a simple Python script to organize
+large raw text dumps into categorized files.
+
+## Usage
+
+1. Place your raw text file (e.g., `raw.txt`) in this directory.
+2. Run `./sort_into_files.py raw.txt` (optionally add `-o output_dir` to
+   place results in a separate folder).
+3. The script will produce several files in the chosen output directory:
+   - `menu.txt` for lines containing `#menu`
+   - `paths.txt` for lines with `/flash/` paths or language files
+   - `errors.txt` for lines mentioning errors or exceptions
+   - `numbers.txt` for purely numeric lines
+   - `other.txt` for all remaining lines
+
+These output files can then be examined or processed separately.

--- a/sort_into_files.py
+++ b/sort_into_files.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Split a raw text file into categorized files.
+
+The script scans each line of the input and sorts it into different
+categories. By default files named ``menu.txt`` ``paths.txt`` ``errors.txt``
+``numbers.txt`` and ``other.txt`` are produced in the working directory.  An
+output directory can be specified with ``-o``.
+"""
+import argparse
+import re
+from pathlib import Path
+
+
+def sort_lines(source_path: str, output_dir: Path):
+    """Stream ``source_path`` and write categorized output files."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    files = {
+        'menu': open(output_dir / 'menu.txt', 'w', encoding='utf-8'),
+        'paths': open(output_dir / 'paths.txt', 'w', encoding='utf-8'),
+        'errors': open(output_dir / 'errors.txt', 'w', encoding='utf-8'),
+        'numbers': open(output_dir / 'numbers.txt', 'w', encoding='utf-8'),
+        'other': open(output_dir / 'other.txt', 'w', encoding='utf-8'),
+    }
+
+    menu_re = re.compile(r'#menu\d+', re.IGNORECASE)
+    path_re = re.compile(r'/flash/|\\LAN', re.IGNORECASE)
+    error_re = re.compile(r'error|exception', re.IGNORECASE)
+    number_re = re.compile(r'^\d+$')
+
+    with open(source_path, 'r', errors='ignore') as fh:
+        for raw in fh:
+            line = raw.rstrip('\n')
+            if not line:
+                continue
+            if menu_re.search(line):
+                target = 'menu'
+            elif path_re.search(line):
+                target = 'paths'
+            elif error_re.search(line):
+                target = 'errors'
+            elif number_re.match(line.strip()):
+                target = 'numbers'
+            else:
+                target = 'other'
+            print(line, file=files[target])
+
+    for f in files.values():
+        f.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description='Categorize lines in a text file.'
+    )
+    parser.add_argument('src', help='input text file')
+    parser.add_argument('-o', '--output', default='.',
+                        help='directory for result files')
+    args = parser.parse_args()
+
+    sort_lines(args.src, Path(args.output))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add output directory option to `sort_into_files.py`
- stream the input file rather than loading it entirely
- update README with revised usage info

## Testing
- `python3 sort_into_files.py sample.txt -o out`


------
https://chatgpt.com/codex/tasks/task_e_6860b9cd6e48832197e62e2f6a029051